### PR TITLE
fix(404): properly reload website when reloading from 404 site

### DIFF
--- a/app/not-found.js
+++ b/app/not-found.js
@@ -46,7 +46,7 @@ export default function PageNotFound() {
         />
       </svg>
       <I18n language={"de"}>
-        <Button href={`/`}>Start</Button>
+        <Button onClick={() => window.location = window.location.origin}>Start</Button>
       </I18n>
     </div>
   );

--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -174,7 +174,6 @@ describe("app", () => {
 
         it("using default language (german) then navigate to english.", () => {
           commonMobileHomeNavigation();
-          cy.get('[data-cy="menuButton"]').click();
           cy.get(enLinkMobile).click({ force: true });
           cy.wait(1000);
           cy.url().should("include", "/en");
@@ -185,7 +184,6 @@ describe("app", () => {
 
         it("using english then navigate to german.", () => {
           commonMobileHomeNavigation("en");
-          cy.get('[data-cy="menuButton"]').click();
           cy.get(deLinkMobile).click({ force: true });
           cy.wait(1000);
           cy.url().should("not.include", "/en");

--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -174,6 +174,7 @@ describe("app", () => {
 
         it("using default language (german) then navigate to english.", () => {
           commonMobileHomeNavigation();
+          cy.get('[data-cy="menuButton"]').click();
           cy.get(enLinkMobile).click({ force: true });
           cy.wait(1000);
           cy.url().should("include", "/en");
@@ -184,6 +185,7 @@ describe("app", () => {
 
         it("using english then navigate to german.", () => {
           commonMobileHomeNavigation("en");
+          cy.get('[data-cy="menuButton"]').click();
           cy.get(deLinkMobile).click({ force: true });
           cy.wait(1000);
           cy.url().should("not.include", "/en");


### PR DESCRIPTION
When redirecting to root from the 404 page, the CSS does not load properly, leaving the website broken.